### PR TITLE
GoSwagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 An implementation of JSON Schema, based on IETF's draft v4 - Go language
 
+## NOTE:
+
+This repo was forked to support validating against partial schemas and fragments to facilitate
+client-side validation of Apcera's goswagger schema.  Our current approach, however, diverted
+to using a proxy server and we no longer required this code to execute the testing locally.
+
+This code is still being merged into our local repo and a PR was submitted to the upstream
+(https://github.com/xeipuuv/gojsonschema/pull/55).
+
 References :
 
 * http://json-schema.org
@@ -145,6 +154,18 @@ To check the result :
             fmt.Printf("- %s\n", desc)
         }
     }
+```
+
+Validation with partial schemas is similar.  It allows the definitions and references in a main
+schema to be used to resolve references and fragments in another document.  Currently, you must
+manually make the references canonical. :
+
+```
+    mainSchema := gojsonschema.NewReferenceLoader(schemaURL)
+    schemaFragment := gojsonschema.NewGoLoader(endpointSchema)
+    doc := gojsonschema.NewStringLoader(someString)
+
+    return ValidatePartialSchema(mainSchema, schemaFragment, doc)
 ```
 
 ## Uses

--- a/goswagger/schema.go
+++ b/goswagger/schema.go
@@ -1,0 +1,222 @@
+package goswagger
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/apcera/gojsonschema"
+)
+
+type Schema struct {
+	Swagger             string                 `json:"swagger"`
+	Host                string                 `json:"host"`
+	BasePath            string                 `json:"basePath"`
+	Info                map[string]string      `json:"info"`
+	Produces            []string               `json:"produces"`
+	Paths               map[string]Path        `json:"paths"`
+	Definitions         map[string]interface{} `json:"definitions"`
+	Parameters          interface{}            `json:"parameters"`
+	Responses           interface{}            `json:"responses"`
+	SecurityDefinitions interface{}            `json:"securityDefinitions"`
+	Security            interface{}            `json:"security"`
+	Tags                interface{}            `json:"tags"`
+	ExternalDocs        interface{}            `json:"externalDocs"`
+}
+
+type Path struct {
+	Ref        string      `json:"ref"`
+	Get        Operation   `json:"get"`
+	Put        Operation   `json:"put"`
+	Post       Operation   `json:"post"`
+	Delete     Operation   `json:"delete"`
+	Options    Operation   `json:"options"`
+	Head       Operation   `json:"head"`
+	Patch      Operation   `json:"patch"`
+	Parameters []Parameter `json:"parameters"`
+}
+
+type Operation struct {
+	Tags         []string    `json:"tags"`
+	Summmary     string      `json:"summary"`
+	Description  string      `json:"description"`
+	ExternalDocs interface{} `json:"externalDocs"`
+	OperationId  string      `json:"operationId"`
+	Consumes     []string    `json:"consumes"`
+	Produces     []string    `json:"produces"`
+	Parameters   []Parameter `json:"parameters"`
+	Responses    interface{} `json:"responses"`
+	Schemes      []string    `json:"schemes"`
+	Deprecated   bool        `json:"deprecated"`
+	Security     interface{} `json:"security"`
+}
+
+type Parameter struct {
+	Name        string                 `json:"name"`
+	In          string                 `json:"in"`
+	Description string                 `json:"description"`
+	Required    bool                   `json:"required"`
+	SchemaDef   map[string]interface{} `json:"schema"`
+}
+
+// Validates a given request against the schema defined for that path/operation in the Swagger spec.
+// Currently only validates the body parameters; does not validate query strings or path parameters.
+func (swag *Schema) ValidateHTTPRequest(req *http.Request) (*gojsonschema.Result, error) {
+	result := &gojsonschema.Result{}
+
+	thisPath, err := GetMatchingPath(swag.Paths, req.URL.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	var op Operation
+	switch req.Method {
+	case "GET":
+		op = thisPath.Get
+	case "POST":
+		op = thisPath.Post
+	case "PUT":
+		op = thisPath.Put
+	case "DELETE":
+		op = thisPath.Delete
+	case "PATCH":
+		op = thisPath.Patch
+	case "OPTIONS":
+		op = thisPath.Options
+	case "HEAD":
+		op = thisPath.Head
+	default:
+		panic(errors.New("Unsupported HTTP operation"))
+	}
+
+	if op.Responses == nil {
+		return nil, errors.New(fmt.Sprintf("The %s operation is not defined on path %s", req.Method, req.URL.Path))
+	}
+
+	for _, p := range op.Parameters {
+		if p.In == "body" {
+			// Load body into schema; delayed until now in case it was unneeded
+			body, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				return nil, err
+			}
+			defer req.Body.Close()
+
+			//fmt.Println("schemaDef is:", p.SchemaDef)
+			ForceCanonicalRefs(swag, p.SchemaDef)
+			//fmt.Println("schemaDef is:", p.SchemaDef)
+			// Validate
+			return ValidatePartialSchema(swag, p.SchemaDef, string(body))
+			_ = body
+		}
+	}
+
+	// Did validate against anthing; reconsider how to handle this
+	return result, nil
+}
+
+// Chooses the swagger path corresponding to the requested url; resolves path parameters
+// in a simple way that isn't very robust.  It doesnt do any validation on the provided {var}
+// even though the path contains schema information for it.
+func GetMatchingPath(pathMap map[string]Path, reqPath string) (*Path, error) {
+	//Simple implentation; if path is a key then dont waste time with regex testing
+	if path, inMap := pathMap[reqPath]; inMap {
+		return &path, nil
+	}
+
+	//get all keys with query params in path
+	var pathUrls []string
+	for k := range pathMap {
+		if strings.Contains(k, "{") {
+			pathUrls = append(pathUrls, k)
+		}
+	}
+
+	//sort keys
+	// TO-DO? Depends if we think that there are multiple routes that really match a given input
+
+	//convert keys to regex
+	pathsAsRegExp := make(map[string]string)
+	re := regexp.MustCompile(`\{(.*?)\}`)
+	for _, k := range pathUrls {
+		pathsAsRegExp[k] = "^" + re.ReplaceAllLiteralString(k, `[^/]*`) + "$"
+	}
+
+	//iterate over and return first which matches
+	for k, v := range pathsAsRegExp {
+		if isMatch, err := regexp.MatchString(v, reqPath); err != nil {
+			return nil, err
+		} else if isMatch {
+			if path, ok := pathMap[k]; ok {
+				return &path, nil
+			}
+		}
+	}
+	return nil, errors.New("Path could not be matched to any in swagger spec.")
+}
+
+// Walks the whole json swagger schema and replaces any refs that just start with # with thef ull canonical ref
+func ForceCanonicalRefs(swag *Schema, obj interface{}) {
+	switch obj.(type) {
+	case map[string]interface{}:
+		// Replace any refs in the map
+		m := obj.(map[string]interface{})
+		if v, inMap := m["$ref"]; inMap && strings.HasPrefix(v.(string), "#") {
+			m["$ref"] = "http://" + swag.Host + "/api-docs" + v.(string)
+		}
+
+		// Call this method with any other maps/arrays in the map.  Allof/AnyOf types register as slices here.
+		for _, v := range m {
+			if reflect.ValueOf(v).Kind() == reflect.Map || reflect.ValueOf(v).Kind() == reflect.Slice {
+				ForceCanonicalRefs(swag, v)
+			}
+		}
+	case []interface{}:
+		for _, v := range obj.([]interface{}) {
+			ForceCanonicalRefs(swag, v)
+		}
+	}
+}
+
+// Get the default swagger spec (URL tbd)
+func GetSwaggerSpec() (*Schema, error) {
+	return GetSwaggerSpecFromURL("http://mockapidemo.john.bagel.buffalo.im/api-docs")
+}
+
+func GetSwaggerSpecFromBytes(b []byte) (*Schema, error) {
+	var swaggerSpec *Schema
+	err := json.Unmarshal(b, &swaggerSpec)
+	if err != nil {
+		return nil, err
+	}
+	return swaggerSpec, nil
+}
+
+func GetSwaggerSpecFromURL(url string) (*Schema, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return GetSwaggerSpecFromBytes(body)
+}
+
+// TODO decide how to better pass in/handle host rather than hardcoding it (or update to location of newer specs).
+// This project is getting dropped for now due to just validating remotely using a proxy server.
+func ValidatePartialSchema(swag *Schema, endpointSchema map[string]interface{}, body string) (*gojsonschema.Result, error) {
+	swaggerSpec := gojsonschema.NewReferenceLoader("http://" + swag.Host + "/api-docs")
+	schemaToValidateAgainst := gojsonschema.NewGoLoader(endpointSchema)
+	doc := gojsonschema.NewStringLoader(body)
+
+	return gojsonschema.ValidatePartialSchema(swaggerSpec, schemaToValidateAgainst, doc)
+}

--- a/goswagger/swagger_test.go
+++ b/goswagger/swagger_test.go
@@ -1,0 +1,151 @@
+package goswagger
+
+import (
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	tt "github.com/apcera/continuum/util/testtool"
+	"github.com/apcera/gojsonschema"
+)
+
+type TestData struct {
+	Operation                string
+	Path                     string
+	Body                     string
+	expectedProcessingError  bool
+	expectedValid            bool
+	expectedValidationErrors int
+}
+
+func TestBasic(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"PUT", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":"c"}`, false, true, 0},
+		{"POST", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":"c", "otherField":0}`, false, true, 0},
+	}
+	ProcessData(t, TestDataSet)
+}
+
+func TestMissingRequired(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"PUT", "/jobs/{uuid}", `{"name":"a", "fqn":"b"}`, false, false, 1},
+		{"POST", "/jobs/{uuid}", `{"name":"a", "uuid":"c", "otherField":0}`, false, false, 1},
+	}
+	ProcessData(t, TestDataSet)
+}
+
+func TestInvalidDataType(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"PUT", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":3}`, false, false, 1},
+		{"POST", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":"c", "ports":3}`, false, false, 1},
+	}
+	ProcessData(t, TestDataSet)
+}
+func TestInvalidDataValue(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"POST", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":"c", "ports":{"number":0}}`, false, true, 0},
+		{"POST", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":"c", "ports":{"number":-1}}`, false, false, 1},
+		{"POST", "/jobs/{uuid}", `{"name":"a", "fqn":"b", "uuid":"c", "ports":{"number":99999999}}`, false, false, 1},
+	}
+	ProcessData(t, TestDataSet)
+}
+
+// Currently, pattern matching is quite forgiving and allows any characters between the '/'.
+func TestPathMatching(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"PUT", "/jobs/abc", `{"name":"a", "fqn":"b", "uuid":"c"}`, false, true, 0},
+		{"POST", "/jobs/993-a93", `{"name":"a", "fqn":"b", "uuid":"c", "otherField":0}`, false, true, 0},
+		{"POST", "/jobs/993&*#@93", `{"name":"a", "fqn":"b", "uuid":"c", "otherField":0}`, false, true, 0},
+		{"POST", "/jobs/99\\3\"&*#@93", `{"name":"a", "fqn":"b", "uuid":"c", "otherField":0}`, false, true, 0},
+	}
+	ProcessData(t, TestDataSet)
+}
+func TestInvalidPaths(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"POST", "/jobs/xyz/", `{"name":"a", "fqn":"b", "uuid":"c", "otherField":0}`, true, true, 0},
+		{"POST", "/jobs/xyz/a", `{"name":"a", "fqn":"b", "uuid":"c", "otherField":0}`, true, true, 0},
+	}
+	ProcessData(t, TestDataSet)
+}
+
+// This functionality is supported through gojsonschema but is not supported by Swagger specification.
+// This is due to uncertainty on their part of how to implement some of their SwaggerUI when there is a
+// range of conditions that are combined with 'AND' or 'OR' statements (allOf, anyOf, oneOf, etc).
+func TestAllOf(t *testing.T) {
+	testHelper := tt.StartTest(t)
+	defer testHelper.FinishTest()
+
+	TestDataSet := []TestData{
+		{"POST", "/jobs/testAllOf", `{"name":"a", "fqn":"b", "uuid":"c", "ports":{"number":0}}`, false, true, 0},
+		// Two errors since violation ports structure (missing) and also a general failure of 'allOf'
+		{"POST", "/jobs/testAllOf", `{"name":"a", "fqn":"b", "uuid":"c"}`, false, false, 2},
+	}
+	ProcessData(t, TestDataSet)
+}
+
+func ProcessData(t *testing.T, ds []TestData) {
+	for _, d := range ds {
+		result, err := ValidateData(t, d.Operation, d.Path, d.Body)
+		if d.expectedProcessingError {
+			t.Logf("Processing error when validating: %s", err)
+			tt.TestExpectError(t, err)
+			continue
+		} else {
+			tt.TestExpectSuccess(t, err)
+		}
+
+		tt.TestNotEqual(t, nil, result)
+		if len(result.Errors()) > 0 {
+			t.Log("RESULT: The document is not valid. see errors :")
+			for _, desc := range result.Errors() {
+				t.Logf("- %s", desc)
+			}
+		}
+		tt.TestEqual(t, result.Valid(), d.expectedValid)
+		tt.TestEqual(t, len(result.Errors()), d.expectedValidationErrors)
+	}
+}
+
+func ValidateData(t *testing.T, op string, path string, body string) (*gojsonschema.Result, error) {
+	t.Logf("Validating test case %s %s %s", op, path, body)
+
+	s, err := ioutil.ReadFile("testSwaggerSpec.json")
+	if err != nil {
+		t.Error("Error reading swagger spec: %s", err)
+		return nil, err
+	}
+	swag, err := GetSwaggerSpecFromBytes(s)
+	if err != nil {
+		t.Errorf("Error while getting swagger spec: %s", err)
+		return nil, err
+	}
+
+	bodyReader := strings.NewReader(body)
+	req, err := http.NewRequest(op, path, bodyReader)
+	if err != nil {
+		t.Errorf("Error while creating HTTP request: %s", err)
+		return nil, err
+	}
+
+	result, err := swag.ValidateHTTPRequest(req)
+	return result, err
+}

--- a/goswagger/testSwaggerSpec.json
+++ b/goswagger/testSwaggerSpec.json
@@ -1,0 +1,183 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "Apcera Continuum REST API",
+        "description": "This is a test version of the API just meant to be run with tests.",
+        "version": "1.0.0"
+    },
+    "produces": [
+        "application/json"
+    ],
+    "host": "locationWhereApiServerMockIs",
+    "basePath": "/v1",
+    "paths": {
+        "/jobs": {
+            "get": {
+                "x-swagger-router-controller": "Jobs",
+                "tags": [
+                    "Jobs"
+                ],
+                "operationId": "jobsGet",
+                "parameters": [{
+                    "name": "FQN",
+                    "in": "query",
+                    "description": "Filter jobs by job FQN",
+                    "required": false,
+                    "type": "string",
+                    "format": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Job"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/jobs/{uuid}": {
+            "put": {
+                "x-swagger-router-controller": "Jobs",
+                "tags": [
+                    "Jobs"
+                ],
+                "operationId": "jobsUuidPut",
+                "parameters": [{
+                    "in": "body",
+                    "name": "Job",
+                    "description": "Job object.",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/Job"
+                    }
+                }, {
+                    "name": "uuid",
+                    "in": "path",
+                    "description": "UUID of the job to fetch.",
+                    "required": true,
+                    "type": "string",
+                    "format": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "Successful response.",
+                        "schema": {
+                            "$ref": "#/definitions/Job"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "x-swagger-router-controller": "Jobs",
+                "tags": [
+                    "Jobs"
+                ],
+                "operationId": "jobsUuidPost",
+                "parameters": [{
+                    "in": "body",
+                    "name": "Job",
+                    "description": "Job object.",
+                    "required": true,
+                    "schema": {
+                        "$ref": "#/definitions/Job"
+                    }
+                }, {
+                    "name": "uuid",
+                    "in": "path",
+                    "description": "UUID of the job to fetch.",
+                    "required": true,
+                    "type": "string",
+                    "format": "string"
+                }],
+                "responses": {
+                    "200": {
+                        "description": "Successful response.",
+                        "schema": {
+                            "$ref": "#/definitions/Job"
+                        }
+                    }
+                }
+            }
+        },
+        "/jobs/testAllOf": {
+            "post": {
+                "x-swagger-router-controller": "Jobs",
+                "tags": [
+                    "Jobs"
+                ],
+                "operationId": "jobsUuidPost",
+                "parameters": [{
+                    "in": "body",
+                    "name": "Job",
+                    "description": "Job object.",
+                    "required": true,
+                    "schema": {
+                        "allOf": [
+                            {"$ref": "#/definitions/Job"}, 
+                            {
+                                "required": [
+                                    "ports"
+                                ]
+                            }
+                        ]
+                    }
+                }],
+                "responses": {
+                    "200": {
+                        "description": "Successful response.",
+                        "schema": {
+                            "$ref": "#/definitions/Job"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Job": {
+            "required": [
+                "fqn",
+                "name",
+                "uuid"
+            ],
+            "properties": {
+                "uuid": {
+                    "type": "string",
+                    "description": "Unique identifier."
+                },
+                "fqn": {
+                    "type": "string",
+                    "description": "Fully Qualified Name."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Name of the provider."
+                },
+                "ports": {
+                    "$ref": "#/definitions/Port"
+                }
+            },
+            "type": "object"
+        },
+        "Port": {
+            "properties": {
+                "number": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0,
+                    "maximum": 65535
+                },
+                "optional": {
+                    "type": "boolean",
+                    "description": "",
+                    "default": false
+                }
+            },
+            "type": "object"
+        }
+    }
+}


### PR DESCRIPTION
These additions allow for a swagger spec to be used with gojsonschema.  Given an
HTTP request to a URL some basic pattern patching is done and the body parameter
is compared against the body parameter in the swagger spec.  This currently
supports more complex gojsonschema constructs like allOf and anyOf even though
swaggerUI itself does not.

The final resting place of this code was meant to be elsewhere but we are putting
this development on hold as local validation is no longer a priority in our tests.
